### PR TITLE
dependabot: vitest関連パッケージの更新を1つのPRにグループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## 概要
- Dependabot の npm 更新で `vitest` と `@vitest/*` を1つのPRにグループ化する
- google-home-voicetext-firebase の `ci/dependabot-group-vitest` と同じ設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)